### PR TITLE
refactor: simplify some of the factory model selection handling

### DIFF
--- a/src/data/device/models/braiins.rs
+++ b/src/data/device/models/braiins.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+pub enum BraiinsModel {
+    #[serde(alias = "BRAIINS MINI MINER BMM 100")]
+    BMM100,
+    #[serde(alias = "BRAIINS MINI MINER BMM 101")]
+    BMM101,
+}

--- a/src/data/device/models/mod.rs
+++ b/src/data/device/models/mod.rs
@@ -53,13 +53,30 @@ pub enum MinerModel {
     Braiins(BraiinsModel),
 }
 
-impl MinerModel {
-    pub fn from_string(
-        make: Option<MinerMake>,
-        firmware: Option<MinerFirmware>,
-        model_str: &str,
-    ) -> Option<Self> {
-        match make {
+pub(crate) struct MinerModelFactory {
+    make: Option<MinerMake>,
+    firmware: Option<MinerFirmware>,
+}
+
+impl MinerModelFactory {
+    pub fn new() -> Self {
+        MinerModelFactory {
+            make: None,
+            firmware: None,
+        }
+    }
+
+    pub(crate) fn with_make(&mut self, make: MinerMake) -> &Self {
+        self.make = Some(make);
+        self
+    }
+    pub(crate) fn with_firmware(&mut self, firmware: MinerFirmware) -> &Self {
+        self.firmware = Some(firmware);
+        self
+    }
+
+    pub(crate) fn parse_model(&self, model_str: &str) -> Option<MinerModel> {
+        match self.make {
             Some(MinerMake::AntMiner) => {
                 let model = AntMinerModel::from_str(model_str).ok();
                 match model {
@@ -74,7 +91,7 @@ impl MinerModel {
                     None => None,
                 }
             }
-            None => match firmware {
+            None => match self.firmware {
                 Some(MinerFirmware::BraiinsOS) => {
                     if let Ok(model) = AntMinerModel::from_str(model_str) {
                         return Some(MinerModel::AntMiner(model));
@@ -94,13 +111,6 @@ impl MinerModel {
                 _ => None,
             },
             _ => None,
-        }
-    }
-    pub fn get_make(&self) -> MinerMake {
-        match self {
-            MinerModel::AntMiner(_) => MinerMake::AntMiner,
-            MinerModel::WhatsMiner(_) => MinerMake::WhatsMiner,
-            MinerModel::Braiins(_) => MinerMake::Braiins,
         }
     }
 }

--- a/src/data/device/models/mod.rs
+++ b/src/data/device/models/mod.rs
@@ -84,6 +84,12 @@ impl MinerModel {
                     }
                     None
                 }
+                Some(MinerFirmware::LuxOS) => {
+                    if let Ok(model) = AntMinerModel::from_str(model_str) {
+                        return Some(MinerModel::AntMiner(model));
+                    }
+                    None
+                }
                 None => None,
                 _ => None,
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
+use crate::data::device::MinerFirmware;
 use crate::data::device::models::MinerModel;
-use crate::data::device::{MinerFirmware, MinerMake};
 use crate::miners::factory::MinerFactory;
 use std::error::Error;
 use std::net::IpAddr;
@@ -9,8 +9,7 @@ pub mod miners;
 
 pub async fn get_miner(
     ip: IpAddr,
-) -> Result<Option<(Option<MinerMake>, Option<MinerModel>, Option<MinerFirmware>)>, Box<dyn Error>>
-{
+) -> Result<Option<(Option<MinerModel>, Option<MinerFirmware>)>, Box<dyn Error>> {
     let factory = MinerFactory::new();
     factory.get_miner(ip).await
 }

--- a/src/miners/factory/mod.rs
+++ b/src/miners/factory/mod.rs
@@ -104,10 +104,7 @@ impl MinerFactory {
     pub async fn get_miner(
         self,
         ip: IpAddr,
-    ) -> Result<
-        Option<(Option<MinerMake>, Option<MinerModel>, Option<MinerFirmware>)>,
-        Box<dyn Error>,
-    > {
+    ) -> Result<Option<(Option<MinerModel>, Option<MinerFirmware>)>, Box<dyn Error>> {
         let search_makes = self.search_makes.clone().unwrap_or(vec![
             MinerMake::AntMiner,
             MinerMake::WhatsMiner,
@@ -174,15 +171,13 @@ impl MinerFactory {
             Some((make, firmware)) => match (make, firmware) {
                 (Some(make), Some(MinerFirmware::Stock)) => {
                     let model = make.get_model(ip).await;
-                    Ok(Some((Some(make), model, firmware)))
+                    Ok(Some((model, firmware)))
                 }
                 (_, Some(firmware)) => {
                     let model = firmware.get_model(ip).await;
                     match model {
-                        Some(model) => {
-                            Ok(Some((Some(model.get_make()), Some(model), Some(firmware))))
-                        }
-                        None => Ok(Some((None, None, Some(firmware)))),
+                        Some(model) => Ok(Some((Some(model), Some(firmware)))),
+                        None => Ok(Some((None, Some(firmware)))),
                     }
                 }
                 _ => Ok(None),
@@ -198,19 +193,22 @@ impl MinerFactory {
         }
     }
 
-    pub fn with_search_makes(&mut self, search_makes: Vec<MinerMake>) {
+    pub fn with_search_makes(&mut self, search_makes: Vec<MinerMake>) -> &Self {
         self.search_makes = Some(search_makes);
+        self
     }
-    pub fn with_search_firmwares(&mut self, search_firmwares: Vec<MinerFirmware>) {
+    pub fn with_search_firmwares(&mut self, search_firmwares: Vec<MinerFirmware>) -> &Self {
         self.search_firmwares = Some(search_firmwares);
+        self
     }
-    pub fn add_search_make(&mut self, search_make: MinerMake) {
+    pub fn add_search_make(&mut self, search_make: MinerMake) -> &Self {
         if self.search_makes.is_none() {
             self.search_makes = Some(vec![search_make]);
         }
         self.search_makes.as_mut().unwrap().push(search_make);
+        self
     }
-    pub fn add_search_firmware(&mut self, search_firmware: MinerFirmware) {
+    pub fn add_search_firmware(&mut self, search_firmware: MinerFirmware) -> &Self {
         if self.search_firmwares.is_none() {
             self.search_firmwares = Some(vec![search_firmware]);
         }
@@ -218,23 +216,26 @@ impl MinerFactory {
             .as_mut()
             .unwrap()
             .push(search_firmware);
+        self
     }
-    pub fn remove_search_make(&mut self, search_make: MinerMake) {
+    pub fn remove_search_make(&mut self, search_make: MinerMake) -> &Self {
         if self.search_makes.is_none() {
-            return;
+            return self;
         }
         self.search_makes
             .as_mut()
             .unwrap()
             .retain(|val| *val != search_make);
+        self
     }
-    pub fn remove_search_firmware(&mut self, search_firmware: MinerFirmware) {
+    pub fn remove_search_firmware(&mut self, search_firmware: MinerFirmware) -> &Self {
         if self.search_firmwares.is_none() {
-            return;
+            return self;
         }
         self.search_firmwares
             .as_mut()
             .unwrap()
             .retain(|val| *val != search_firmware);
+        self
     }
 }

--- a/src/miners/factory/model.rs
+++ b/src/miners/factory/model.rs
@@ -1,4 +1,4 @@
-use crate::data::device::{MinerMake, MinerModel};
+use crate::data::device::{MinerFirmware, MinerMake, MinerModel};
 use crate::miners::util;
 use diqwest::WithDigestAuth;
 use reqwest::{Client, Response};
@@ -14,7 +14,8 @@ pub(crate) async fn get_model_antminer(ip: IpAddr) -> Option<MinerModel> {
         Some(data) => {
             let json_data = data.json::<serde_json::Value>().await.ok()?;
             MinerModel::from_string(
-                MinerMake::AntMiner,
+                Some(MinerMake::AntMiner),
+                None,
                 &json_data["minertype"].as_str().unwrap_or("").to_uppercase(),
             )
         }
@@ -33,7 +34,7 @@ pub(crate) async fn get_model_whatsminer(ip: IpAddr) -> Option<MinerModel> {
             model.pop();
             model.push('0');
 
-            MinerModel::from_string(MinerMake::WhatsMiner, &model)
+            MinerModel::from_string(Some(MinerMake::WhatsMiner), None, &model)
         }
         None => None,
     }
@@ -48,7 +49,7 @@ pub(crate) async fn get_model_luxos(ip: IpAddr) -> Option<MinerModel> {
             }
             let model = model.unwrap().to_uppercase();
 
-            MinerModel::from_string(MinerMake::AntMiner, &model)
+            MinerModel::from_string(None, Some(MinerFirmware::LuxOS), &model)
         }
         None => None,
     }

--- a/src/miners/factory/traits.rs
+++ b/src/miners/factory/traits.rs
@@ -42,6 +42,7 @@ impl ModelSelection for MinerFirmware {
     async fn get_model(&self, ip: IpAddr) -> Option<MinerModel> {
         match self {
             MinerFirmware::LuxOS => model::get_model_luxos(ip).await,
+            MinerFirmware::BraiinsOS => model::get_model_braiins_os(ip).await,
             _ => None,
         }
     }


### PR DESCRIPTION
This should help simplify some of the code and make the functions in the `MinerFactory` much cleaner.  I moved the `MinerModel` creation functionality to a `MinerModelFactory` which should allow dynamic construction of the model in the future if needed.  Also added Braiins OS discovery support with both the `Braiins` make and the `BraiinsOS` firmware.