### PR TITLE
feature: add RPC API design for LUXMiner

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,16 @@
+use asic_rs::miners::api::rpc::luxminer::LUXMinerRPC;
+use asic_rs::miners::api::rpc::traits::SendRPCCommand;
+use serde_json::Value;
 use std::net::IpAddr;
-
-use asic_rs::get_miner;
 
 #[tokio::main]
 async fn main() {
     let miner_ip = IpAddr::from([192, 168, 86, 34]);
+    let port: u16 = 4028;
 
-    let miner_info = get_miner(miner_ip).await.unwrap();
-    dbg!(miner_info);
+    let miner_rpc = LUXMinerRPC::new(miner_ip, Some(port));
+    dbg!(miner_rpc.send_command::<Value>("devdetails").await);
+
+    // let miner_info = get_miner(miner_ip).await.unwrap();
+    // dbg!(miner_info);
 }

--- a/src/miners/api/mod.rs
+++ b/src/miners/api/mod.rs
@@ -1,0 +1,1 @@
+pub mod rpc;

--- a/src/miners/api/rpc/errors.rs
+++ b/src/miners/api/rpc/errors.rs
@@ -1,0 +1,33 @@
+use serde_json::Error;
+use std::fmt::{Debug, Display, Formatter};
+
+#[derive(Debug)]
+pub enum RPCError {
+    StatusCheckFailed(String),
+    DeserializationFailed(Error),
+    ConnectionFailed,
+}
+
+impl Display for RPCError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RPCError::StatusCheckFailed(message) => {
+                write!(f, "Command returned with error status: {}", message)
+            }
+            RPCError::DeserializationFailed(error) => {
+                write!(f, "Failed to deserialize result: {}", error)
+            }
+            RPCError::ConnectionFailed => {
+                write!(f, "Failed to connect to RPC API")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RPCError {}
+
+impl From<Error> for RPCError {
+    fn from(value: Error) -> Self {
+        Self::DeserializationFailed(value)
+    }
+}

--- a/src/miners/api/rpc/luxminer.rs
+++ b/src/miners/api/rpc/luxminer.rs
@@ -1,0 +1,73 @@
+use crate::miners::api::rpc::errors::RPCError;
+use crate::miners::api::rpc::status::RPCCommandStatus;
+use crate::miners::api::rpc::traits::SendRPCCommand;
+use serde::de::DeserializeOwned;
+use std::net::IpAddr;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+pub struct LUXMinerRPC {
+    ip: IpAddr,
+    port: u16,
+}
+
+impl LUXMinerRPC {
+    pub fn new(ip: IpAddr, port: Option<u16>) -> Self {
+        Self {
+            ip,
+            port: port.unwrap_or(4028),
+        }
+    }
+}
+impl RPCCommandStatus {
+    fn from_luxminer(response: &str) -> Result<Self, RPCError> {
+        let value: serde_json::Value = serde_json::from_str(response)?;
+        let message = value["STATUS"][0]["Msg"].as_str();
+
+        match value["STATUS"][0]["STATUS"].as_str() {
+            None => Err(RPCError::StatusCheckFailed(
+                message
+                    .unwrap_or("Unknown error when looking for status code")
+                    .to_owned(),
+            )),
+            Some(value) => Ok(Self::from_str(value, message)),
+        }
+    }
+}
+
+impl SendRPCCommand for LUXMinerRPC {
+    async fn send_command<T>(&self, command: &'static str) -> Result<T, RPCError>
+    where
+        T: DeserializeOwned,
+    {
+        let stream = tokio::net::TcpStream::connect(format!("{}:{}", self.ip, self.port)).await;
+        if stream.is_err() {
+            return Err(RPCError::ConnectionFailed);
+        }
+        let mut stream = stream.unwrap();
+
+        let command = format!("{{\"command\":\"{command}\"}}");
+
+        stream.write_all(command.as_bytes()).await.unwrap();
+
+        let mut buffer = Vec::new();
+        stream.read_to_end(&mut buffer).await.unwrap();
+
+        let response = String::from_utf8_lossy(&buffer)
+            .into_owned()
+            .replace('\0', "");
+
+        self.parse_rpc_result::<T>(&response)
+    }
+
+    fn parse_rpc_result<T>(&self, response: &str) -> Result<T, RPCError>
+    where
+        T: DeserializeOwned,
+    {
+        let status = RPCCommandStatus::from_luxminer(response)?;
+
+        match status.into_result() {
+            Ok(_) => Ok(serde_json::from_str(response)?),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/src/miners/api/rpc/mod.rs
+++ b/src/miners/api/rpc/mod.rs
@@ -1,0 +1,4 @@
+mod errors;
+pub mod luxminer;
+pub mod status;
+pub mod traits;

--- a/src/miners/api/rpc/status.rs
+++ b/src/miners/api/rpc/status.rs
@@ -1,0 +1,30 @@
+use crate::miners::api::rpc::errors::RPCError;
+
+pub enum RPCCommandStatus {
+    Success,
+    Information,
+    Error(String),
+    Unknown,
+}
+
+impl RPCCommandStatus {
+    pub fn into_result(self) -> Result<(), RPCError> {
+        match self {
+            RPCCommandStatus::Success => Ok(()),
+            RPCCommandStatus::Information => Ok(()),
+            RPCCommandStatus::Error(msg) => Err(RPCError::StatusCheckFailed(msg)),
+            RPCCommandStatus::Unknown => {
+                Err(RPCError::StatusCheckFailed(String::from("Unknown status")))
+            }
+        }
+    }
+
+    pub fn from_str(response: &str, message: Option<&str>) -> Self {
+        match response {
+            "S" => RPCCommandStatus::Success,
+            "I" => RPCCommandStatus::Information,
+            "E" => RPCCommandStatus::Error(message.unwrap_or("Unknown error").to_string()),
+            _ => RPCCommandStatus::Unknown,
+        }
+    }
+}

--- a/src/miners/api/rpc/traits.rs
+++ b/src/miners/api/rpc/traits.rs
@@ -1,0 +1,12 @@
+use crate::miners::api::rpc::errors::RPCError;
+use serde::de::DeserializeOwned;
+
+pub trait SendRPCCommand {
+    async fn send_command<T>(&self, command: &'static str) -> Result<T, RPCError>
+    where
+        T: DeserializeOwned;
+
+    fn parse_rpc_result<T>(&self, response: &str) -> Result<T, RPCError>
+    where
+        T: DeserializeOwned;
+}

--- a/src/miners/mod.rs
+++ b/src/miners/mod.rs
@@ -1,3 +1,4 @@
+pub mod api;
 pub mod commands;
 pub mod factory;
 pub(crate) mod util;


### PR DESCRIPTION
Attempt a setup for an RPC API (for LUXMiner since that's what I have access to right now).  Couple caveats here  with the way this is being done, to try to add some flexibility in the future:

- The `SendRPCCommand` trait expects a type `T` which in the general case will be `serde_json::Value`, which can be a bit annoying, but the goal with this is that ideally the user should not use this function, and instead internally we can optimize memory usage by parsing the raw socket response directly into a type that contains all the data we want, then discarding the rest of the response.  We would implement a type `LUXMinerDevdetailsData` which would parse only the important data, which could then be put into `MinerData`.  This also solves the same problem as the dynamic `_get_data` function in pyasic in that it will ensure that each unique command is only ever sent 1 time.
- `send_rpc_command` does not take a `MinerCommand` (yet), as I think that type will need to be extended with parameters.  Not sure how best to handle this, so leaving this starting implementation as basic as possible to review the underlying idea.