### PR TITLE
Changed Extractor Functions to Returns Refs Instead of Cloning

### DIFF
--- a/src/miners/backends/traits.rs
+++ b/src/miners/backends/traits.rs
@@ -1,10 +1,17 @@
+use async_trait::async_trait;
 use crate::data::miner::MinerData;
 use crate::miners::data::{DataField, DataLocation};
-use async_trait::async_trait;
 
+/// Trait that every miner backend must implement to provide miner data.
 #[async_trait]
 pub trait GetMinerData: Send + Sync {
+    /// Asynchronously retrieves standardized information about a miner,
+    /// returning it as a `MinerData` struct.
     async fn get_data(&self) -> MinerData;
 
+    /// Returns the locations of the specified data field on the miner.
+    ///
+    /// This associates API commands (routes) with `DataExtractor` structs,
+    /// describing how to extract the data for a given `DataField`.
     fn get_locations(&self, data_field: DataField) -> &'static [DataLocation];
 }


### PR DESCRIPTION
- Improved data collection module by adding documentation to clarify its usage. 

- Changed return types to `&Value`  instead of cloned values to optimize performance.  
This approach avoids unnecessary cloning in the common case of read-only access while preserving the ability to clone if mutation is needed. 

