### PR TITLE
docs: add documentation for `MinerData`

### DIFF
--- a/src/data/board.rs
+++ b/src/data/board.rs
@@ -3,29 +3,51 @@ use measurements::{Frequency, Temperature, Voltage};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ChipData {
+    /// The position of the chip on the board, indexed from 0
     pub position: u16,
+    /// The current hashrate of the chip
     pub hashrate: Option<HashRate>,
+    /// The current chip temperature
     pub temperature: Option<Temperature>,
+    /// The voltage set point for this chip
     pub voltage: Option<Voltage>,
+    /// The frequency set point for this chip
     pub frequency: Option<Frequency>,
+    /// Whether this chip is tuned and optimizations have completed
     pub tuned: Option<bool>,
+    /// Whether this chip is working and actively mining
     pub working: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct BoardData {
+    /// The board position in the miner, indexed from 0
     pub position: u8,
+    /// The current hashrate of the board
     pub hashrate: Option<HashRate>,
+    /// The expected or factory hashrate of the board
     pub expected_hashrate: Option<HashRate>,
+    /// The board temperature, also sometimes called PCB temperature
     pub board_temperature: Option<Temperature>,
+    /// The temperature of the chips at the intake, usually from the first sensor on the board
     pub intake_temperature: Option<Temperature>,
+    /// The temperature of the chips at the outlet, usually from the last sensor on the board
     pub outlet_temperature: Option<Temperature>,
+    /// The expected number of chips on this board
     pub expected_chips: Option<u16>,
+    /// The number of working chips on this board
     pub working_chips: Option<u16>,
+    /// The serial number of this board
     pub serial_number: Option<String>,
+    /// Chip level information for this board
+    /// May be empty, most machines do not provide this level of in depth information
     pub chips: Vec<ChipData>,
+    /// The average voltage or voltage set point of this board
     pub voltage: Option<Voltage>,
+    /// The average frequency or frequency set point of this board
     pub frequency: Option<Frequency>,
+    /// Whether this board has been tuned and optimizations have completed
     pub tuned: Option<bool>,
+    /// Whether this board is enabled and actively mining
     pub active: Option<bool>,
 }

--- a/src/data/fan.rs
+++ b/src/data/fan.rs
@@ -2,6 +2,9 @@ use measurements::AngularVelocity;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FanData {
+    /// The position or index of the fan as seen by the device
+    /// Usually dependent on where to fan is connected to the control board
     pub position: i16,
+    /// The RPM of the fan
     pub rpm: AngularVelocity,
 }

--- a/src/data/hashrate.rs
+++ b/src/data/hashrate.rs
@@ -16,8 +16,11 @@ pub enum HashRateUnit {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct HashRate {
+    /// The current amount of hashes being computed
     pub value: f64,
+    /// The unit of the hashes in value
     pub unit: HashRateUnit,
+    /// The algorithm of the computed hashes
     pub algo: String,
 }
 

--- a/src/data/message.rs
+++ b/src/data/message.rs
@@ -7,8 +7,13 @@ pub enum MessageSeverity {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MinerMessage {
+    /// The time this message was generated or occurred
     pub timestamp: u32,
+    /// The message code
+    /// May be set to 0 if no code is set by the device
     pub code: u64,
+    /// The human-readable message being relayed by the device
     pub message: String,
+    /// The severity of this message
     pub severity: MessageSeverity,
 }

--- a/src/data/miner.rs
+++ b/src/data/miner.rs
@@ -10,32 +10,60 @@ use super::{
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct MinerData {
+    /// The schema version of this MinerData object, for use in external APIs
     pub schema_version: String,
+    /// The time this data was gathered and constructed
     pub timestamp: u64,
+    /// The IP address of the miner this data is for
     pub ip: IpAddr,
+    /// The MAC address of the miner this data is for
     pub mac: Option<MacAddr>,
+    /// Hardware information about this miner
     pub device_info: DeviceInfo,
+    /// The serial number of the miner, also known as the control board serial
     pub serial_number: Option<String>,
+    /// The network hostname of the miner
     pub hostname: Option<String>,
+    /// The API version of the miner
     pub api_version: Option<String>,
+    /// The firmware version of the miner
     pub firmware_version: Option<String>,
+    /// The type of control board on the miner
     pub control_board_version: Option<String>,
+    /// The expected number of boards in the miner.
     pub expected_hashboards: Option<u8>,
+    /// Per-hashboard data for this miner
     pub hashboards: Vec<BoardData>,
+    /// The current hashrate of the miner
     pub hashrate: Option<HashRate>,
+    /// The total expected number of chips across all boards on this miner
     pub expected_chips: Option<u16>,
+    /// The total number of working chips across all boards on this miner
     pub total_chips: Option<u16>,
+    /// The expected number of fans on the miner
     pub expected_fans: Option<u8>,
+    /// The current fan information for the miner
     pub fans: Vec<FanData>,
+    /// The current PDU fan information for the miner
     pub psu_fans: Vec<FanData>,
+    /// The average temperature across all chips in the miner
     pub average_temperature: Option<Temperature>,
+    /// The environment temperature of the miner, such as air temperature or immersion fluid temperature
     pub fluid_temperature: Option<Temperature>,
+    /// The current power consumption of the miner
     pub wattage: Option<Power>,
+    /// The current power limit or power target of the miner
     pub wattage_limit: Option<Power>,
+    /// The current efficiency in W/TH/s (J/TH) of the miner
     pub efficiency: Option<f64>,
+    /// The state of the fault/alert light on the miner
     pub light_flashing: Option<bool>,
+    /// Any message on the miner, including errors
     pub messages: Vec<MinerMessage>,
+    /// The total uptime of the miner's system
     pub uptime: Option<Duration>,
+    /// Whether the hashing process is currently running
     pub is_mining: bool,
+    /// The current pools configured on the miner
     pub pools: Vec<PoolData>,
 }

--- a/src/data/pool.rs
+++ b/src/data/pool.rs
@@ -20,9 +20,14 @@ impl From<String> for PoolScheme {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PoolURL {
+    /// The scheme being used to connect to this pool
     pub scheme: PoolScheme,
+    /// The public host of the pool
     pub host: String,
+    /// The port being used to connect to the pool
     pub port: u16,
+    /// The public key for this pool
+    /// Only used for Stratum V2 pools
     pub pubkey: Option<String>,
 }
 


### PR DESCRIPTION
Added documentation for the `MinerData` struct and subitems.

Should look at adding `::new()` functions for these, as sections of this data should be computed from data at lower levels, such as averages and chip counts.